### PR TITLE
renamed movie link to movie preview 

### DIFF
--- a/food.js
+++ b/food.js
@@ -102,7 +102,7 @@ function displayMovieOptions(x) {
             <div class="card-body">
             <h5 class="card-title">${item.titleText.text}</h5>
             <p class="card-text"></p>
-            <a href="https://www.imdb.com/title/${item.id}/" target="_blank" class="btn">Movie link</a>
+            <a href="https://www.imdb.com/title/${item.id}/" target="_blank" class="btn">Movie Preview</a>
             </div>
             </div>
             `

--- a/movie-api.js
+++ b/movie-api.js
@@ -45,7 +45,7 @@ function displayMovieOptions(x) {
 				// 				<div class="card-body">
 				// 					<h5 class="card-title">${item.titleText.text}</h5>
 				// 					<p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
-				// 					<a href="#" class="btn btn-primary">Movie link</a>
+				// 					<a href="#" class="btn btn-primary">Movie Preview</a>
 				// 				</div>
 				// 			</div>
 				// `


### PR DESCRIPTION
Renamed button to "movie preview" instead of "movie link" for the sake of accuracy and to not create confusion